### PR TITLE
refactor translator interface

### DIFF
--- a/packages/languages/tsconfig.json
+++ b/packages/languages/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.settings.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "dist"
   },
   "include": ["src", "locales"]

--- a/packages/translator/__tests__/translator.test.ts
+++ b/packages/translator/__tests__/translator.test.ts
@@ -3,48 +3,86 @@ import {
   Translator,
   TranslateOptions,
   TranslateResult,
+  TranslateQueryResult,
   Languages
 } from "../src";
 
-jest.setTimeout(20000);
+describe("Translator", () => {
+  it("should successfully return result", async () => {
+    class TestTranslator extends Translator {
+      name = "test";
 
-class TestTranslator extends Translator {
-  name = "test";
+      getSupportLanguages(): Languages {
+        return ["en"];
+      }
 
-  getSupportLanguages(): Languages {
-    return ["en"];
-  }
-  query(text: string, options: TranslateOptions): Promise<TranslateResult> {
-    return Promise.resolve({
-      text: text,
+      query(
+        text: string,
+        options: TranslateOptions
+      ): Promise<TranslateQueryResult> {
+        return Promise.resolve({
+          text: text,
+          from: options.from,
+          to: options.to,
+          origin: {
+            text: "origin text",
+            tts: "https://test.com/tts.mp3"
+          },
+          trans: {
+            text: "origin text",
+            tts: "https://test.com/tts.mp3"
+          }
+        });
+      }
+    }
+
+    const translator: Translator = new TestTranslator();
+
+    const options: TranslateOptions = {
+      from: "en",
+      to: "zh-CN"
+    };
+
+    const result = await translator.translate("hello", options);
+
+    expect(result).toEqual({
+      engine: "test",
+      text: "hello",
       from: options.from,
       to: options.to,
-      status: "SUCCESS"
+      origin: {
+        text: "origin text",
+        tts: "https://test.com/tts.mp3"
+      },
+      trans: {
+        text: "origin text",
+        tts: "https://test.com/tts.mp3"
+      }
     });
-  }
-}
+  }, 20000);
 
-class FailTranslator extends Translator {
-  name = "FailTranslator";
+  it("should throw error when failed", async () => {
+    class FailTranslator extends Translator {
+      name = "FailTranslator";
 
-  getSupportLanguages(): Languages {
-    return ["en"];
-  }
-  query(text: string, options: TranslateOptions): Promise<TranslateResult> {
-    return Promise.reject({ status: "UNKNOWN" });
-  }
-}
+      getSupportLanguages(): Languages {
+        return ["en"];
+      }
 
-test("translator query", async () => {
-  const translator: Translator = new TestTranslator();
-  const options: TranslateOptions = {
-    from: "en",
-    to: "en"
-  };
-  await translator.translate("hello", options).then(res => {
-    expect(res.status).toBe("SUCCESS");
-  });
-  await new FailTranslator().translate("hello", options).catch(res => {
-    expect(res.status).toBe("UNKNOWN");
-  });
+      query(text: string, options: TranslateOptions): Promise<TranslateResult> {
+        return Promise.reject(new Error("UNKNOWN"));
+      }
+    }
+
+    const options: TranslateOptions = {
+      from: "en",
+      to: "zh-CN"
+    };
+
+    try {
+      await new FailTranslator().translate("hello", options);
+    } catch (e) {
+      expect(e.message).toBe("UNKNOWN");
+    }
+  }, 20000);
 });

--- a/packages/translator/src/index.ts
+++ b/packages/translator/src/index.ts
@@ -1,8 +1,3 @@
-export { languages } from "@opentranslate/languages";
-export { Translator } from "./translator";
-export {
-  TranslateResult,
-  TranslateOptions,
-  Languages,
-  TranslateStatus
-} from "./type";
+export * from "@opentranslate/languages";
+export * from "./type";
+export * from "./translator";

--- a/packages/translator/src/translator.ts
+++ b/packages/translator/src/translator.ts
@@ -2,7 +2,8 @@ import {
   Languages,
   TranslatorEnv,
   TranslateOptions,
-  TranslateResult
+  TranslateResult,
+  TranslateQueryResult
 } from "./type";
 import { Language } from "@opentranslate/languages";
 import Axios, { AxiosInstance, AxiosRequestConfig, AxiosPromise } from "axios";
@@ -46,25 +47,15 @@ export abstract class Translator {
    * @returns {Promise<TranslateResult>}
    * @memberof Translator
    */
-  translate(text: string, options: TranslateOptions): Promise<TranslateResult> {
-    return this.postTranslate(this.query(text, options));
-  }
-
-  /**
-   * 无需实现
-   * 翻译后处理，添加翻译源信息
-   * @private
-   * @param {Promise<TranslateResult>} res
-   * @returns {Promise<TranslateResult>}
-   * @memberof Translator
-   */
-  private postTranslate(
-    res: Promise<TranslateResult>
+  async translate(
+    text: string,
+    options: TranslateOptions
   ): Promise<TranslateResult> {
-    return res.then(res => {
-      res.engine = this.name;
-      return Promise.resolve(res);
-    });
+    const queryResult = await this.query(text, options);
+    return {
+      ...queryResult,
+      engine: this.name
+    };
   }
 
   /**
@@ -74,13 +65,13 @@ export abstract class Translator {
    * @abstract
    * @param {string} text
    * @param {TranslateOptions} options
-   * @returns {Promise<TranslateResult>}
+   * @returns {Promise<TranslateQueryResult>}
    * @memberof Translator
    */
   protected abstract query(
     text: string,
     options: TranslateOptions
-  ): Promise<TranslateResult>;
+  ): Promise<TranslateQueryResult>;
 
   /**
    * 跨平台 xhr 请求方法。

--- a/packages/translator/src/type.ts
+++ b/packages/translator/src/type.ts
@@ -4,8 +4,7 @@ export type Languages = Array<Language>;
 
 export type TranslatorEnv = "node" | "ext";
 
-export type TranslateStatus =
-  | "SUCCESS"
+export type TranslateError =
   | "NETWORK_ERROR"
   | "NETWORK_TIMEOUT"
   | "API_SERVER_ERROR"
@@ -13,14 +12,23 @@ export type TranslateStatus =
 
 /** 统一的查询结果的数据结构 */
 export interface TranslateResult {
+  engine: string;
   text: string;
   from: Language;
   to: Language;
-  status: TranslateStatus;
-  result?: string;
-  url?: string;
-  engine?: string;
+  /** 原文 */
+  origin: {
+    text: string;
+    tts?: string;
+  };
+  /** 译文 */
+  trans: {
+    text: string;
+    tts?: string;
+  };
 }
+
+export type TranslateQueryResult = Omit<TranslateResult, "engine">;
 
 /** 统一的查询参数结构 */
 export interface TranslateOptions {

--- a/packages/translator/tsconfig.json
+++ b/packages/translator/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../tsconfig.settings.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "dist"
   },
-  "include": ["src"],
-  "references": [{ "path": "../languages" }]
+  "include": ["src"]
 }


### PR DESCRIPTION
- 返回的类型固定为
   ```js
   export interface TranslateResult {
     engine: string;
     text: string;
     from: Language;
     to: Language;
     /** 原文 */
     origin: {
       text: string;
       tts?: string;
     };
     /** 译文 */
     trans: {
       text: string;
       tts?: string;
     };
   }
   ```
2. 去掉 `postTranslate` 归并到 `translate` 中
3. `TranslateStatus` 改为 `TranslateError` 。有返回结果即为成功，失败结果通过异常 `catch` 。
