### PR TITLE
refactor(languages): remove explicit export type

### DIFF
--- a/packages/languages/src/index.ts
+++ b/packages/languages/src/index.ts
@@ -1,2 +1,2 @@
-export { languages, Language } from "./languages";
-export { Locale } from "./locales";
+export * from "./languages";
+export * from "./locales";


### PR DESCRIPTION
兼容 `--isolatedModules`  模式，此模式下无法区分去除 export 的 type 。