### PR TITLE
Fix baidu textToSpeech (TTS)

### DIFF
--- a/packages/service-baidu-domain/src/index.ts
+++ b/packages/service-baidu-domain/src/index.ts
@@ -118,13 +118,12 @@ export class BaiduDomain extends Translator<BaiduDomainConfig> {
   }
 
   async textToSpeech(text: string, lang: Language): Promise<string> {
-    return `http://tts.baidu.com/text2audio?${qs.stringify({
+    return `https://fanyi.baidu.com/gettts?${qs.stringify({
       lan: BaiduDomain.langMap.get(lang !== "auto" ? lang : "zh-CN") || "zh",
-      ie: "UTF-8",
+      text,
       spd: 5,
-      text
     })}`;
-  }
+  }  
 }
 
 export default BaiduDomain;

--- a/packages/service-baidu/src/index.ts
+++ b/packages/service-baidu/src/index.ts
@@ -134,13 +134,12 @@ export class Baidu extends Translator<BaiduConfig> {
   }
 
   async textToSpeech(text: string, lang: Language): Promise<string> {
-    return `http://tts.baidu.com/text2audio?${qs.stringify({
+    return `https://fanyi.baidu.com/gettts?${qs.stringify({
       lan: Baidu.langMap.get(lang !== "auto" ? lang : "zh-CN") || "zh",
-      ie: "UTF-8",
-      spd: 5,
-      text
+      text,
+      spd: 3,
     })}`;
-  }
+  }  
 }
 
 export default Baidu;

--- a/packages/service-baidu/src/index.ts
+++ b/packages/service-baidu/src/index.ts
@@ -137,7 +137,7 @@ export class Baidu extends Translator<BaiduConfig> {
     return `https://fanyi.baidu.com/gettts?${qs.stringify({
       lan: Baidu.langMap.get(lang !== "auto" ? lang : "zh-CN") || "zh",
       text,
-      spd: 3,
+      spd: 5,
     })}`;
   }  
 }

--- a/packages/service-caiyun/src/index.ts
+++ b/packages/service-caiyun/src/index.ts
@@ -40,13 +40,13 @@ export class Caiyun extends Translator<CaiyunConfig> {
   }
 
   async textToSpeech(text: string, lang: Language): Promise<string> {
-    return `http://tts.baidu.com/text2audio?${qs.stringify({
+    return `https://fanyi.baidu.com/gettts?${qs.stringify({
       lan: Caiyun.langMap.get(lang !== "auto" ? lang : "zh-CN") || "zh",
-      ie: "UTF-8",
+      text,
       spd: 5,
-      text
     })}`;
   }
+  
 
   protected async query(
     text: string,


### PR DESCRIPTION
Baidu has changed the text to speech API URL, this patch should work.
Test results:
```
@Ayx03 ➜ /workspaces/OpenTranslate (baidu-tts-patch) $ npm run test

> test
> lerna run build && lerna run test

lerna notice cli v3.16.4
lerna info Executing command in 10 packages: "yarn run build"
lerna info run Ran npm script 'build' in '@opentranslate/languages' in 3.7s:
yarn run v1.22.19
$ rm -rf dist && tsc --project tsconfig.build.json
Done in 3.32s.
lerna info run Ran npm script 'build' in '@opentranslate/translator' in 3.4s:
yarn run v1.22.19
$ rm -rf dist && tsc --project tsconfig.build.json
Done in 3.12s.
lerna info run Ran npm script 'build' in '@opentranslate/baidu-domain' in 6.7s:
yarn run v1.22.19
$ rm -rf dist && tsc --project tsconfig.build.json
Done in 6.36s.
lerna info run Ran npm script 'build' in '@opentranslate/baidu' in 6.9s:
yarn run v1.22.19
$ rm -rf dist && tsc --project tsconfig.build.json
Done in 6.61s.
lerna info run Ran npm script 'build' in '@opentranslate/caiyun' in 6.7s:
yarn run v1.22.19
$ rm -rf dist && tsc --project tsconfig.json
Done in 6.28s.
lerna info run Ran npm script 'build' in '@opentranslate/deepl' in 6.9s:
yarn run v1.22.19
$ rm -rf dist && tsc --project tsconfig.build.json
Done in 6.63s.
lerna info run Ran npm script 'build' in '@opentranslate/google' in 7.3s:
yarn run v1.22.19
$ rm -rf dist && tsc --project tsconfig.build.json
Done in 6.80s.
lerna info run Ran npm script 'build' in '@opentranslate/sogou' in 7.1s:
yarn run v1.22.19
$ rm -rf dist && tsc --project tsconfig.build.json
Done in 6.75s.
lerna info run Ran npm script 'build' in '@opentranslate/youdao' in 6.4s:
yarn run v1.22.19
$ rm -rf dist && tsc --project tsconfig.build.json
Done in 6.09s.
lerna info run Ran npm script 'build' in '@opentranslate/tencent' in 7.0s:
yarn run v1.22.19
$ rm -rf dist && tsc --project tsconfig.build.json
Done in 6.61s.
lerna success run Ran npm script 'build' in 10 packages in 34.7s:
lerna success - @opentranslate/languages
lerna success - @opentranslate/baidu-domain
lerna success - @opentranslate/baidu
lerna success - @opentranslate/caiyun
lerna success - @opentranslate/deepl
lerna success - @opentranslate/google
lerna success - @opentranslate/sogou
lerna success - @opentranslate/tencent
lerna success - @opentranslate/youdao
lerna success - @opentranslate/translator
lerna notice cli v3.16.4
lerna info Executing command in 10 packages: "yarn run test"
lerna info run Ran npm script 'test' in '@opentranslate/languages' in 4.2s:
yarn run v1.22.19
$ jest
Done in 3.96s.
lerna info run Ran npm script 'test' in '@opentranslate/translator' in 3.5s:
yarn run v1.22.19
$ jest
Done in 3.29s.
lerna ERR! yarn run test exited 1 in '@opentranslate/baidu-domain'
lerna ERR! yarn run test stdout:
yarn run v1.22.19
$ jest --runInBand --forceExit --detectOpenHandles
  console.error src/index.ts:75
    Error: [BaiduDomain service]UNAUTHORIZED USER
        at BaiduDomain.query (/workspaces/OpenTranslate/packages/service-baidu-domain/src/index.ts:76:9)
        at processTicksAndRejections (node:internal/process/task_queues:95:5)
        at BaiduDomain.translate (/workspaces/OpenTranslate/packages/translator/src/translator.ts:50:25)
        at Object.<anonymous> (/workspaces/OpenTranslate/packages/service-baidu-domain/__tests__/baidu-domain.test.ts:13:20)

info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

lerna ERR! yarn run test stderr:
FAIL baidu-domain __tests__/baidu-domain.test.ts (5.733s)
  Dict BaiduDomain
    ✕ should translate en2zh successfully (470ms)
    ✕ should translate zh2en successfully (133ms)
    ✓ should get supported languages (2ms)

  ● Dict BaiduDomain › should translate en2zh successfully

    API_SERVER_ERROR

      79 |         )
      80 |       );
    > 81 |       throw new TranslateError("API_SERVER_ERROR");
         |             ^
      82 |     }
      83 | 
      84 |     const {

      at BaiduDomain.query (src/index.ts:81:13)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at BaiduDomain.translate (../translator/src/translator.ts:50:25)
      at Object.<anonymous> (__tests__/baidu-domain.test.ts:13:20)

  ● Dict BaiduDomain › should translate zh2en successfully

    API_SERVER_ERROR

      79 |         )
      80 |       );
    > 81 |       throw new TranslateError("API_SERVER_ERROR");
         |             ^
      82 |     }
      83 | 
      84 |     const {

      at BaiduDomain.query (src/index.ts:81:13)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at BaiduDomain.translate (../translator/src/translator.ts:50:25)
      at Object.<anonymous> (__tests__/baidu-domain.test.ts:38:20)

Test Suites: 1 failed, 1 total
Tests:       2 failed, 1 passed, 3 total
Snapshots:   0 total
Time:        5.774s
Ran all test suites.
error Command failed with exit code 1.

lerna ERR! yarn run test exited 1 in '@opentranslate/baidu-domain'
lerna WARN complete Waiting for 2 child processes to exit. CTRL-C to exit immediately.
```